### PR TITLE
action: enable CI and release automation

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,28 @@
+---
+# Creates a new GitHub release if the version in gradle.properties changed in the main branch.
+name: create-tag
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - gradle.properties
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create release
+        run: |
+          APM_AGENT_ANDROID_VERSION="v$(grep agent_version gradle.properties | cut -d'=' -f2)"
+          gh release create "${APM_AGENT_ANDROID_VERSION}" \
+            --title="${APM_AGENT_ANDROID_VERSION}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -4,6 +4,8 @@ name: OpenTelemetry Export Trace
 on:
   workflow_run:
     workflows:
+      - create-tag
+      - test
       - updatecli
     types: [completed]
 

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -1,0 +1,20 @@
+---
+## Workflow to process the JUnit test results and add a report to the checks.
+name: test-reporter
+on:
+  workflow_run:
+    workflows:
+      - test
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
+        with:
+          artifact: test-results            # artifact name
+          name: JUnit Tests                 # Name of the check run which will be created
+          path: "**/*.xml"                  # Path to test results (inside artifact .zip)
+          reporter: java-junit              # Format of test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: test
+
+on:
+  create:
+    tags: [ "v*" ]
+  push:
+    branches: [ "main" ]
+  pull_request: ~
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: lint
+      run: ./gradlew lint
+
+    - name: Build
+      run: ./gradlew assemble
+
+    - name: Test
+      run: ./gradlew test
+
+    - name: Store test results
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: target/*.xml

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-agent_version=0.9.0
+agent_version=0.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-agent_version=0.8.0
+agent_version=0.9.0


### PR DESCRIPTION
Enable CI for this project
Release is automated similarly done with the other opbeans projects. When `gradle.properties` changes then it will create a Tag release using the APM Agent Android version.

Other opbeans projects use docker images that are published in https://hub.docker.com/u/opbeans

I don't know whether this project will need to support that particular use case, if so, we can discuss further and plan the next actions in a follow up